### PR TITLE
refactor: goalId를 위한 useParams 커스텀 훅으로 분리

### DIFF
--- a/src/features/create-todo/ui/CreateTodoForm.tsx
+++ b/src/features/create-todo/ui/CreateTodoForm.tsx
@@ -4,16 +4,17 @@ import { useCreateTodoMutation } from '../model/hooks';
 import ToggleButton from './ToggleButton';
 import ConfirmButton from '@/features/create-todo/ui/ConfirmButton';
 import CheckTodoBlankIcon from '@/assets/check_todo_blank.svg';
+import { useGoalId } from '@/shared/model/useGoalId';
 
 const IS_ADMIN = true;
 
 export default function CreateTodoForm() {
+  const goalId = useGoalId();
   const { content, setContent } = useCreateTodoStore();
   const { isInvalid, setIsInvalid } = useCreateTodoStore();
   const { isShared, toggleIsShared } = useCreateTodoStore();
   const { resetField, toggleEditMode } = useCreateTodoStore();
-
-  const createTodo = useCreateTodoMutation('goal-1');
+  const createTodo = useCreateTodoMutation(goalId);
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (content.trim() === '') {

--- a/src/features/delete-todo/ui/DeleteTodoDropDownButton.tsx
+++ b/src/features/delete-todo/ui/DeleteTodoDropDownButton.tsx
@@ -2,16 +2,16 @@ import DotsIcon from '@/assets/dots.svg';
 import { useRef } from 'react';
 import { useModal } from '@/shared/lib/utils/useModal';
 import { useDeleteTodoMutation } from '../model/hooks';
+import { useGoalId } from '@/shared/model/useGoalId';
 
 export default function DeleteTodoDropDownButton({
-  goalId,
   todoId,
 }: {
-  goalId: string;
   todoId: string;
 }) {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const { open, close } = useModal();
+  const goalId = useGoalId();
   const deleteTodo = useDeleteTodoMutation(goalId);
   const items = [
     {

--- a/src/features/update-todo/ui/update-todo.tsx
+++ b/src/features/update-todo/ui/update-todo.tsx
@@ -1,16 +1,16 @@
 import CheckTodoBlankIcon from '@/assets/check_todo_blank.svg';
 import CheckTodoFillIcon from '@/assets/check_todo_fill.svg';
 import { useUpdateTodoMutation } from '../model/hooks/useUpdateTodo';
+import { useGoalId } from '@/shared/model/useGoalId';
 
 export default function UpdateTodoCompletionCheckbox({
   completed,
-  goalId,
   todoId,
 }: {
   completed: boolean;
-  goalId: string;
   todoId: string;
 }) {
+  const goalId = useGoalId();
   const updateTodo = useUpdateTodoMutation(goalId);
 
   return (

--- a/src/shared/model/useGoalId.ts
+++ b/src/shared/model/useGoalId.ts
@@ -1,0 +1,21 @@
+import { useParams } from 'next/navigation'; // next/router in older versions
+import { useEffect } from 'react';
+
+export const useGoalId = (): string => {
+  const params = useParams<{ goalId: string }>();
+  const goalId = params?.goalId;
+
+  // 기본 에러 처리: goalId가 없으면 404 페이지로 보내거나 toast 띄우기
+  useEffect(() => {
+    if (!goalId) {
+      // 예: toast.error('유효하지 않은 goalId입니다.');
+      // 혹은 router.push('/404');
+    }
+  }, [goalId]);
+
+  if (!goalId) {
+    throw new Error('goalId가 존재하지 않습니다');
+  }
+
+  return goalId;
+};

--- a/src/widgets/todo/ui/todo.tsx
+++ b/src/widgets/todo/ui/todo.tsx
@@ -5,16 +5,13 @@ import type { Todo } from '../model';
 import UpdateTodoCompletionCheckbox from '@/features/update-todo/ui/update-todo';
 import DeleteTodoDropDownButton from '@/features/delete-todo/ui/DeleteTodoDropDownButton';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
 
 export default function Todo({ todo }: { todo: Todo }) {
-  const params = useParams<{ goalId: string }>() as { goalId: string };
   return (
     <div className="bg-surface-4 text-text-primary flex h-72 w-full items-center justify-between rounded-lg px-18">
       <div className="flex items-center justify-center gap-14">
         <UpdateTodoCompletionCheckbox
           completed={todo.completed}
-          goalId={params.goalId}
           todoId={todo.id}
         />
         <TodoInfo todo={todo} />
@@ -30,7 +27,7 @@ export default function Todo({ todo }: { todo: Todo }) {
             <NewNoteIcon width={32} height={32} />
           )}
         </Link>
-        <DeleteTodoDropDownButton goalId={params.goalId} todoId={todo.id} />
+        <DeleteTodoDropDownButton todoId={todo.id} />
       </div>
     </div>
   );

--- a/src/widgets/todolist-detail/ui/TodolistPanel.tsx
+++ b/src/widgets/todolist-detail/ui/TodolistPanel.tsx
@@ -9,9 +9,9 @@ import { useTodolistQuery } from '@/entities/todolist/model/hooks';
 import divideTodoGroup from '@/entities/todolist/lib/utils/divideTodoGroup';
 import { useEffect } from 'react';
 import { useTodolistStore } from '@/entities/todolist/model/store';
-import { useParams } from 'next/navigation';
 import ConfirmButton from '@/features/create-todo/ui/ConfirmButton';
 import toast from 'react-hot-toast';
+import { useGoalId } from '@/shared/model/useGoalId';
 
 function TitleArea({ title = '목표' }: { title?: string }) {
   const toggleEditMode = useCreateTodoStore((state) => state.toggleEditMode);
@@ -42,8 +42,8 @@ function TitleArea({ title = '목표' }: { title?: string }) {
 }
 
 export default function TodolistPanel() {
-  const params = useParams<{ goalId: string }>();
-  const { data, isLoading } = useTodolistQuery(params?.goalId);
+  const goalId = useGoalId();
+  const { data, isLoading } = useTodolistQuery(goalId);
   const { setAllGroup } = useTodolistStore();
 
   useEffect(() => {
@@ -53,12 +53,7 @@ export default function TodolistPanel() {
     setAllGroup(newDone, newShared, newPersonal);
   }, [data, setAllGroup]);
 
-  if (!params || isLoading)
-    return (
-      <>
-        {JSON.stringify(params)} / Loading:{String(isLoading)}
-      </>
-    );
+  if (isLoading) return <>Loading</>;
 
   return (
     <LayoutGroup>


### PR DESCRIPTION
## 📌 PR 제목

goalId를 위한 useParams 커스텀 훅으로 분리

---

## 📄 변경 내용

- Todolist 상세페이지 각 하위 컴포넌트에서 goalId 를 위해 사용하던 useParams 별도 커스텀 훅으로 분리
- 투두 완료 체크박스 버튼 / 삭제 버튼 / 투두 생성 폼에 적용
