### PR TITLE
feat: useTodolistQuery 데이터 파싱 계층 추가

### DIFF
--- a/src/entities/todolist/api/mock/mocks.ts
+++ b/src/entities/todolist/api/mock/mocks.ts
@@ -4,7 +4,7 @@ export const myTodolist = {
   order: ['todo-1', 'todo-2', 'todo-3', 'todo-4', 'todo-5', 'todo-6'],
   todolist: [
     {
-      id: 'todo-1',
+      todoId: 'todo-1',
       content: '1.튜토리얼 영상 1-3 시청',
       createdAt: new Date('2025-01-10T09:00:00Z'),
       completed: true,
@@ -14,7 +14,7 @@ export const myTodolist = {
       shared: true,
     },
     {
-      id: 'todo-2',
+      todoId: 'todo-2',
       content: '2.사용자 인터뷰 실습 준비',
       createdAt: new Date('2025-01-10T10:00:00Z'),
       completed: false,
@@ -24,7 +24,7 @@ export const myTodolist = {
       shared: true,
     },
     {
-      id: 'todo-3',
+      todoId: 'todo-3',
       content: '3.프로토타입 제작',
       createdAt: new Date('2025-01-10T10:00:00Z'),
       completed: false,
@@ -34,7 +34,7 @@ export const myTodolist = {
       shared: true,
     },
     {
-      id: 'todo-4',
+      todoId: 'todo-4',
       content: '4.주요 단축키 정리 노션에 업로드',
       createdAt: new Date('2025-01-10T10:00:00Z'),
       completedAt: new Date(),
@@ -44,7 +44,7 @@ export const myTodolist = {
       shared: false,
     },
     {
-      id: 'todo-5',
+      todoId: 'todo-5',
       content: '5.키 인사이트 3개 도출해서 슬랙에 공유',
       createdAt: new Date('2025-01-10T10:00:00Z'),
       completedAt: undefined,
@@ -54,7 +54,7 @@ export const myTodolist = {
       shared: false,
     },
     {
-      id: 'todo-6',
+      todoId: 'todo-6',
       content: '6.간단한 모바일 UI 따라 그리기',
       createdAt: new Date('2025-01-10T10:00:00Z'),
       completedAt: undefined,

--- a/src/entities/todolist/api/mock/todolistHanlders.ts
+++ b/src/entities/todolist/api/mock/todolistHanlders.ts
@@ -15,12 +15,14 @@ export const todolistHandlers = [
     const todolist = myTodolist.todolist;
 
     const orderedTodolist = order.map((currTodoId) =>
-      todolist.find((todo) => todo.id === currTodoId),
+      todolist.find((todo) => todo.todoId === currTodoId),
     );
 
     const orderedMockData = {
-      title: myTodolist.title,
-      todolist: orderedTodolist,
+      data: {
+        title: myTodolist.title,
+        myTodoList: orderedTodolist,
+      },
     };
 
     return HttpResponse.json(orderedMockData, { status: 200 });
@@ -36,7 +38,7 @@ export const todolistHandlers = [
     const newId = String(idCounter++).repeat(4);
 
     const newTodo = {
-      id: newId,
+      todoId: newId,
       content: body.content,
       createdAt: new Date(Date.now()),
       completed: false,
@@ -57,7 +59,9 @@ export const todolistHandlers = [
       todoId: string;
       priorityOrder: number;
     };
-    const deletedOrder = myTodolist.order.filter((id) => id !== body.todoId);
+    const deletedOrder = myTodolist.order.filter(
+      (todoId) => todoId !== body.todoId,
+    );
     deletedOrder.splice(body.priorityOrder, 0, body.todoId);
     myTodolist.order = deletedOrder;
     return HttpResponse.json({ status: 201 });
@@ -73,7 +77,7 @@ export const todolistHandlers = [
     };
 
     const targetIndexInTodolist = myTodolist.todolist.findIndex(
-      (todo) => todo.id === todoId,
+      (todo) => todo.todoId === todoId,
     );
 
     if (targetIndexInTodolist === -1) {
@@ -97,7 +101,7 @@ export const todolistHandlers = [
     if ((body as { completed: boolean }).completed) {
       const lastCompletedIndex = myTodolist.order.findIndex(
         (currTodoId) =>
-          !myTodolist.todolist.find((todo) => todo.id === currTodoId)
+          !myTodolist.todolist.find((todo) => todo.todoId === currTodoId)
             ?.completed,
       );
       if (lastCompletedIndex < 0) {
@@ -115,13 +119,15 @@ export const todolistHandlers = [
   // DELETE: 투두 삭제
   http.delete('/api/todos/:todoId', async ({ params }) => {
     const { todoId } = params;
-    const index = myTodolist.todolist.findIndex((todo) => todo.id === todoId);
+    const index = myTodolist.todolist.findIndex(
+      (todo) => todo.todoId === todoId,
+    );
     if (index === -1) {
       return HttpResponse.json({ status: 404, message: 'Todo not found' });
     }
 
     myTodolist.todolist.splice(index, 1);
-    myTodolist.order = myTodolist.order.filter((id) => id !== todoId);
+    myTodolist.order = myTodolist.order.filter((todoId) => todoId !== todoId);
     return HttpResponse.json({ status: 204 });
   }),
 ];

--- a/src/entities/todolist/model/hooks/useTodolistQuery.ts
+++ b/src/entities/todolist/model/hooks/useTodolistQuery.ts
@@ -1,12 +1,32 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchTodolist } from '../../api/fetchTodolist';
-import { Todolist } from '../types';
+import { FetchTodoListResponse, Todolist } from '../types';
 import { todolistQueryKeys } from '../queryKeys';
 
 export const useTodolistQuery = (goalId?: string) => {
-  return useQuery<Todolist>({
+  return useQuery<FetchTodoListResponse, Error, Todolist>({
     queryKey: [...todolistQueryKeys.todolist(goalId as string)],
     queryFn: () => fetchTodolist(goalId as string),
     enabled: !!goalId,
+    select: (response: FetchTodoListResponse) => {
+      const myTodoList = response.data.myTodoList;
+
+      const parsedMyTodoList = myTodoList.map((todo) => ({
+        // role: todolist.role,
+        id: todo.todoId,
+        content: todo.content,
+        createdAt: todo.createdAt,
+        completedAt: todo.completedAt,
+        completed: todo.completed,
+        note: todo.note,
+        noteId: todo.noteId,
+        shared: todo.shared,
+        // priorityOrder: todo.priorityOrder,
+      }));
+      return {
+        title: response.data.title ?? null,
+        todolist: parsedMyTodoList,
+      };
+    },
   });
 };

--- a/src/entities/todolist/model/types.ts
+++ b/src/entities/todolist/model/types.ts
@@ -10,7 +10,34 @@ export interface Todo {
 }
 
 export interface Todolist {
-  goalId: string;
   title: string;
   todolist: Todo[];
+}
+
+export interface FetchTodoListResponse {
+  httpStatusCode: number;
+  errorCode: 'string';
+  data: {
+    title: string;
+    myTodoList: [
+      {
+        todoId: string;
+        content: string;
+        completed: boolean;
+        createdAt: string;
+        completedAt: string;
+        note: string;
+        noteId: string;
+        shared: boolean;
+        priorityOrder: number;
+      },
+    ];
+  };
+  errorMessage: 'string';
+  fieldErrors: [
+    {
+      field: 'string';
+      message: 'string';
+    },
+  ];
 }


### PR DESCRIPTION
## 📌 PR 제목

useTodolistQuery 데이터 파싱 계층 추가 / 타입 조정

## 📄 변경 내용

- todos api 관련 msw handler - swagger 호환되도록 수정
- fetchTodolistResponse type 추가
- 서버로부터 받는 Todolist 데이터 속성 명 파싱 계층 추가 (useTodolistQuery.select)