### PR TITLE
fix: 노트 상세 정보 불러오기 시 타입 에러 해결

### DIFF
--- a/src/entities/note/model/mock/handler/noteHandler.ts
+++ b/src/entities/note/model/mock/handler/noteHandler.ts
@@ -58,9 +58,7 @@ export const noteHandlers = [
     return HttpResponse.json({
       httpStatusCode: 200,
       errorCode: null,
-      data: {
-        note: note
-      },
+      data: note,
       errorMessage: null
     });
   }),
@@ -109,9 +107,7 @@ export const noteHandlers = [
     return HttpResponse.json({
       httpStatusCode: 200,
       errorCode: null,
-      data: {
-        note: updatedNote
-      },
+      data: updatedNote,
       errorMessage: null
     });
   }),

--- a/src/entities/note/model/types.ts
+++ b/src/entities/note/model/types.ts
@@ -11,9 +11,7 @@ export interface Note {
 export interface NoteResponse {
   httpStatusCode: number;
   errorCode: string | null;
-  data: {
-    note: Note;
-  };
+  data: Note;
   errorMessage: string | null;
 }
 

--- a/src/pages/note/ui/NoteEditPage.tsx
+++ b/src/pages/note/ui/NoteEditPage.tsx
@@ -7,8 +7,7 @@ import NoteListPageIcon from '@/assets/note-list-page-icon.svg';
 
 export function NoteEditPage({ noteId }: { noteId: number }) {
   const { data: noteResponse, isLoading, isError } = useGetNoteById(noteId);
-
-  const note = noteResponse?.data?.note;
+  const note = noteResponse?.data;
   const updateNoteMutation = useUpdateNote();
 
   const handleAutoSave = (content: string) => {


### PR DESCRIPTION

## 📄 변경 내용

- todo 컴포넌트의 노트 아이콘 클릭 시, NoteEditPage 컴포넌트에서 노트 정보가 매핑되지 않는 오류 해결