### PR TITLE
fix: NoteEditor 커서 위치 초기화 현상 해결

### DIFF
--- a/src/features/edit-note/ui/NoteEditor.tsx
+++ b/src/features/edit-note/ui/NoteEditor.tsx
@@ -57,7 +57,17 @@ export function NoteEditor({ initialNote, onAutoSave }: NoteEditorProps) {
 
   useEffect(() => {
     if (editor && initialNote) {
-      editor.commands.setContent(initialNote.content);
+      const { from, to } = editor.state.selection;
+
+      editor.commands.setContent(initialNote.content, {
+        emitUpdate: false,
+        parseOptions: {
+          preserveWhitespace: 'full',
+        },
+        errorOnInvalidContent: true,
+      });
+
+      editor.commands.setTextSelection({ from, to });
     }
   }, [editor, initialNote]);
 
@@ -91,10 +101,10 @@ export function NoteEditor({ initialNote, onAutoSave }: NoteEditorProps) {
 
   return (
     <div className="space-y-6">
-      <div className="rounded-md bg-surface-3">
+      <div className="bg-surface-3 rounded-md">
         <EditorContent
           editor={editor}
-          className="h-[300px] overflow-y-auto px-36 py-34 focus:outline-none text-white"
+          className="h-[300px] overflow-y-auto px-36 py-34 text-white focus:outline-none"
         />
         <NoteEditorMenu editor={editor} />
       </div>
@@ -108,7 +118,9 @@ export function NoteEditor({ initialNote, onAutoSave }: NoteEditorProps) {
               <span className="text-text-tertiary body-medium">작성 중...</span>
             )}
             {status === 'saved' && (
-              <span className="body-medium text-highlight">자동 저장되었습니다.</span>
+              <span className="body-medium text-highlight">
+                자동 저장되었습니다.
+              </span>
             )}
           </span>
         )}

--- a/src/features/edit-note/ui/NoteEditor.tsx
+++ b/src/features/edit-note/ui/NoteEditor.tsx
@@ -94,7 +94,7 @@ export function NoteEditor({ initialNote, onAutoSave }: NoteEditorProps) {
       <div className="rounded-md bg-surface-3">
         <EditorContent
           editor={editor}
-          className="h-[300px] overflow-y-auto px-36 py-34 focus:outline-none"
+          className="h-[300px] overflow-y-auto px-36 py-34 focus:outline-none text-white"
         />
         <NoteEditorMenu editor={editor} />
       </div>


### PR DESCRIPTION
## 📄 변경 내용

- NoteEditor가 브라우저 테마에 상관없이 흰색이도록 css 지정
- NoteEditor에서 글 작성 후 디바운싱 업데이트할 때, 키보드 커서가 작성된 글 맨 뒤로 이동하는 현상 해결