### PR TITLE
refator: NoteEditor 포커스 적용 및 빈 문자열인 경우 placeholder 표시되도룩 적용

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -228,6 +228,14 @@ body {
   margin: 0.25em 0;
 }
 
+.ProseMirror p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  float: left;
+  color: #adb5bd;
+  pointer-events: none;
+  height: 0;
+}
+
 /* prose 커스텀: NoteCard에서 h1~h4, bold에 text-text-primary 적용 */
 .prose h1,
 .prose h2,

--- a/src/features/update-note/ui/NoteEditor.tsx
+++ b/src/features/update-note/ui/NoteEditor.tsx
@@ -55,6 +55,18 @@ export function NoteEditor({ initialNote, onAutoSave }: NoteEditorProps) {
     immediatelyRender: false,
   });
 
+  // 에디터가 준비되면 자동으로 focus
+  useEffect(() => {
+    if (editor) {
+      const timer = setTimeout(() => {
+        editor.commands.focus('end');
+      }, 100);
+
+      return () => clearTimeout(timer);
+    }
+  }, [editor]);
+
+  // 초기 노트 내용 설정 및 커서 위치 설정
   useEffect(() => {
     if (editor && initialNote) {
       const { from, to } = editor.state.selection;
@@ -71,6 +83,7 @@ export function NoteEditor({ initialNote, onAutoSave }: NoteEditorProps) {
     }
   }, [editor, initialNote]);
 
+  // 상태 메시지 표시 및 페이드 아웃
   useEffect(() => {
     if (status === 'typing') {
       setShowStatus(true);
@@ -90,6 +103,7 @@ export function NoteEditor({ initialNote, onAutoSave }: NoteEditorProps) {
     };
   }, [status]);
 
+  // 타이머 정리
   useEffect(() => {
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);

--- a/src/features/update-note/ui/NoteEditor.tsx
+++ b/src/features/update-note/ui/NoteEditor.tsx
@@ -29,7 +29,7 @@ export function NoteEditor({ initialNote, onAutoSave }: NoteEditorProps) {
       }),
       Underline,
       Highlight,
-      Placeholder.configure({ placeholder: '노트 내용을 입력하세요...' }),
+      Placeholder.configure({ placeholder: '노트를 적어주세요!' }),
     ],
     content: initialNote?.content || '',
     onUpdate: ({ editor }) => {


### PR DESCRIPTION

## 📄 변경 내용

- NoteEditPage 접속 시,  NoteEditor에 키보드 커서가 문자열 가장 끝으로 focus 되도록 구현.
- NoteEditor에 적용된 content가 빈 문자열인 경우 placeholder(노트를 적어주세요!)가 표시되도록 적용.
---

## 📸 UI 스크린샷

<img width="493" height="741" alt="note-edit-focus-placeholder" src="https://github.com/user-attachments/assets/44159803-4df5-47ce-958e-f325597101de" />

---

## 📝 기타 참고 사항
