### PR TITLE
middleware - 로그인 확인 , 리다이렉트 로직 분리

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -43,8 +43,6 @@ export async function middleware(req: NextRequest) {
   const needsLoginCheck =
     isDashboard || isNote || isAccount || isRoot || isTodo;
 
-  const needsRoute = isLoginToDashboard || isRoot;
-
   if (needsLoginCheck) {
     const res = await fetch(
       `${process.env.NEXT_PUBLIC_API_URL}/api/auth/check`,
@@ -58,83 +56,9 @@ export async function middleware(req: NextRequest) {
       },
     );
     const loginRes: AuthCheckResponse = await res.json();
-    console.log(loginRes);
-
     if (loginRes.httpStatusCode !== 200) {
       return NextResponse.redirect(new URL('/auth/login', req.url));
     }
   }
-  // 로그인 O
-  if (needsRoute) {
-    const timestamp = Date.now();
-    const studyRes = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/study?_t=${timestamp}`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'Cache-Control': 'no-cache, no-store, must-revalidate',
-          Pragma: 'no-cache',
-          Expires: '0',
-          cookie,
-        },
-        cache: 'no-store',
-      },
-    );
-
-    if (!studyRes.ok) {
-      // 스터디 안불러지는 경우 에러처리 필요
-      return NextResponse.redirect(new URL('/', req.url));
-    }
-
-    const studyListRes: StudyListResponseApi = await studyRes.json();
-    const studyList = studyListRes.data;
-
-    if (studyListRes.httpStatusCode === 200 && studyList.totalCount !== 0) {
-      const goalTimestamp = Date.now();
-      const goalRes = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/api/studies/${studyList.studyList[0].studyId}/goals?_t=${goalTimestamp}`,
-        {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-            'Cache-Control': 'no-cache, no-store, must-revalidate',
-            Pragma: 'no-cache',
-            Expires: '0',
-            cookie,
-          },
-          cache: 'no-store',
-        },
-      );
-
-      if (!goalRes.ok) {
-        // 목표 안불러지는 경우 에러처리 필요
-        return NextResponse.redirect(new URL('/', req.url));
-      }
-      const goalListRes: GoalListResponseApi = await goalRes.json();
-      const goalList = goalListRes.data;
-      if (goalListRes.httpStatusCode === 200 && goalList.totalCount !== 0) {
-        // 2. 스터디O, 목표O
-        return NextResponse.redirect(
-          new URL(
-            `/dashboard/study/${studyList.studyList[0].studyId}/goal/${goalList.goals[0].id}`,
-            req.url,
-          ),
-        );
-      } else {
-        // 2. 스터디O, 목표X
-        return NextResponse.redirect(
-          new URL(
-            `/dashboard/study/${studyList.studyList[0].studyId}`,
-            req.url,
-          ),
-        );
-      }
-    } else {
-      // 3. 스터디X, 목표X
-      return NextResponse.redirect(new URL(`/dashboard/study`, req.url));
-    }
-  }
-
   return NextResponse.next();
 }

--- a/src/entities/study/model/__mocks__/study.mock.ts
+++ b/src/entities/study/model/__mocks__/study.mock.ts
@@ -6,7 +6,7 @@ export const mockStudyListResponseApi: StudyListResponseApi = {
   errorMessage: '',
   fieldErrors: [],
   data: {
-    totalCount: 0,
+    totalCount: 6,
     recentStudyId: 1,
     studyList: [
       {

--- a/src/features/auth-login/model/useLogin.ts
+++ b/src/features/auth-login/model/useLogin.ts
@@ -3,12 +3,14 @@
 import { LoginSchema } from '@/features/auth-login';
 import { requestLogin } from '@/entities/auth/api';
 import { useRouter } from 'next/navigation';
+import { useRedirect } from '@/shared/lib/utils/useRedirect';
 import { useCustomMutation } from '@/shared/lib/utils/useCustomMutation';
 import { useProfileStore } from '@/entities/profile/model';
 
 export function useLogin() {
   const router = useRouter();
   const { setProfile } = useProfileStore();
+  const url = useRedirect('study');
   return useCustomMutation({
     mutationFn: (data: LoginSchema) => requestLogin(data),
     mutationOptions: {
@@ -16,7 +18,11 @@ export function useLogin() {
         //localStorage에 email, nickname, profileImg 저장
         const { email, nickname, profileImg } = res.data;
         setProfile(nickname, email, profileImg);
-        router.replace('/dashboard');
+        if (url) {
+          router.replace(url);
+        } else {
+          router.replace('/dashboard');
+        }
       },
     },
   });

--- a/src/features/auth-login/model/useLogin.ts
+++ b/src/features/auth-login/model/useLogin.ts
@@ -21,7 +21,7 @@ export function useLogin() {
         if (url) {
           router.replace(url);
         } else {
-          router.replace('/dashboard');
+          router.replace('/');
         }
       },
     },

--- a/src/features/delete-goal/model/useDeleteGoal.ts
+++ b/src/features/delete-goal/model/useDeleteGoal.ts
@@ -29,9 +29,9 @@ export const useDeleteGoalMutation = (goalId: string, studyId: string) => {
     mutationOptions: {
       onSuccess: () => {
         if (url) {
-          router.push(url);
+          router.replace(url);
         } else {
-          router.push('/');
+          router.replace('/');
         }
       },
     },

--- a/src/features/delete-goal/model/useDeleteGoal.ts
+++ b/src/features/delete-goal/model/useDeleteGoal.ts
@@ -7,6 +7,7 @@ import { deleteGoals } from '../api';
 import { studyQueryKeys } from '@/entities/study';
 import { goalQueryKeys } from '@/entities/goal';
 import { useRouter } from 'next/navigation';
+import { useRedirect } from '@/shared/lib/utils/useRedirect';
 
 interface DeleteGoalMutationParams {
   goalId: string;
@@ -14,21 +15,24 @@ interface DeleteGoalMutationParams {
 }
 export const useDeleteGoalMutation = (goalId: string, studyId: string) => {
   const router = useRouter();
+  const url = useRedirect('goal', studyId);
 
   return useCustomMutation<DeleteGoalMutationParams, any>({
     mutationFn: ({ goalId }) => deleteGoals(goalId),
     invalidateQueryKeys: [
       //대시보드 쿼리 무효화
       [...dashboardQueryKeys.goal(goalId)],
-      //스터디 리스트 쿼리 무효화
-      [...studyQueryKeys.list()],
       //목표 리스트 쿼리 무효화
       [...goalQueryKeys.list(Number(studyId))],
     ],
     successMessage: '목표가 삭제되었습니다',
     mutationOptions: {
       onSuccess: () => {
-        router.push('/');
+        if (url) {
+          router.push(url);
+        } else {
+          router.push('/');
+        }
       },
     },
   });

--- a/src/features/delete-study/model/useDeleteStudy.ts
+++ b/src/features/delete-study/model/useDeleteStudy.ts
@@ -7,12 +7,14 @@ import { deleteStudy } from '../api';
 import { studyQueryKeys } from '@/entities/study';
 import { goalQueryKeys } from '@/entities/goal';
 import { useRouter } from 'next/navigation';
+import { useRedirect } from '@/shared/lib/utils/useRedirect';
 
 interface DeleteStudyMutationParams {
   studyId: string;
 }
 export const useDeleteStudyMutation = (studyId: string) => {
   const router = useRouter();
+  const url = useRedirect();
 
   return useCustomMutation<DeleteStudyMutationParams, any>({
     mutationFn: ({ studyId }) => deleteStudy(studyId),
@@ -27,7 +29,11 @@ export const useDeleteStudyMutation = (studyId: string) => {
     successMessage: '스터디가 삭제되었습니다',
     mutationOptions: {
       onSuccess: () => {
-        router.push('/');
+        if (url) {
+          router.push(url);
+        } else {
+          router.push('/');
+        }
       },
     },
   });

--- a/src/features/delete-study/model/useDeleteStudy.ts
+++ b/src/features/delete-study/model/useDeleteStudy.ts
@@ -30,9 +30,9 @@ export const useDeleteStudyMutation = (studyId: string) => {
     mutationOptions: {
       onSuccess: () => {
         if (url) {
-          router.push(url);
+          router.replace(url);
         } else {
-          router.push('/');
+          router.replace('/');
         }
       },
     },

--- a/src/shared/lib/utils/useRedirect.ts
+++ b/src/shared/lib/utils/useRedirect.ts
@@ -1,0 +1,54 @@
+// 목적지 url만 반환하는 훅
+import { useGetStudy } from '@/entities/study/model/useGetStudy';
+import { useGetGoal } from '@/entities/goal/model/useGetGoal';
+
+/**
+ * 스터디/목표 존재 여부에 따라 대시보드 내에서 적절한 경로로 리다이렉트하는 훅
+ *
+ * useRedirect(); // 페이지 진입 시 자동 라우팅
+ */
+
+type DeleteType = 'study' | 'goal';
+
+/**
+ * @param deleteType 'study' | 'goal' (삭제 타입)
+ * @param studyId goal 삭제 시 기준이 되는 스터디 id (goal 삭제 시 필수)
+ */
+export function useRedirect(
+  deleteType: DeleteType = 'study',
+  studyId?: string | number,
+) {
+  let baseStudyId: string | number | undefined;
+  let isStudyFetched = true;
+  let studyData: any = undefined;
+
+  // 스터디 데이터 가져오기
+  if (deleteType === 'study') {
+    const study = useGetStudy();
+    studyData = study.data;
+    isStudyFetched = study.isFetched;
+    baseStudyId = studyData?.studyList?.[0]?.id;
+  } else {
+    // 타입이 goal인 경우 스터디 id값 사용
+    baseStudyId = studyId;
+  }
+  const studyIdNum = Number(baseStudyId);
+  const { data: goalData, isFetched: isGoalFetched } = useGetGoal(studyIdNum, {
+    enabled: !!studyIdNum,
+  });
+
+  // 목적지 url만 반환
+  if (!isStudyFetched) return undefined;
+  if (deleteType === 'study' && (!studyData || studyData.totalCount === 0)) {
+    return '/dashboard/study';
+  }
+  if (!baseStudyId || isNaN(studyIdNum)) {
+    return '/dashboard/study';
+  }
+  if (!isGoalFetched) return undefined;
+  if (goalData && goalData.totalCount !== 0) {
+    return `/dashboard/study/${baseStudyId}/goal/${goalData.goals[0].id}`;
+  } else {
+    return `/dashboard/study/${baseStudyId}`;
+  }
+}

--- a/src/widgets/guide/ui/guide.tsx
+++ b/src/widgets/guide/ui/guide.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { motion, AnimatePresence, PanInfo } from 'framer-motion';
 import { useRouter } from 'next/navigation';
 import { cn } from '@/shared/lib/utils/cn';
 import { Button } from '@/shared/ui';
+import { useRedirect } from '@/shared/lib/utils/useRedirect';
 
 const images = [
   '/images/guide/guide_1.png',
@@ -46,6 +47,13 @@ export default function Guide() {
   const [current, setCurrent] = useState(0);
   const router = useRouter();
   const [slideDirection, setSlideDirection] = useState(0);
+
+  const url = useRedirect('study'); // 스터디/목표 기준 자동 리다이렉트
+  useEffect(() => {
+    if (url) {
+      router.replace(url);
+    }
+  }, [url, router]);
 
   // 슬라이드 애니메이션 설정
   const slideVariants = {

--- a/src/widgets/guide/ui/guide.tsx
+++ b/src/widgets/guide/ui/guide.tsx
@@ -47,12 +47,15 @@ export default function Guide() {
   const [current, setCurrent] = useState(0);
   const router = useRouter();
   const [slideDirection, setSlideDirection] = useState(0);
+  const [loading, setLoading] = useState(true);
 
   const url = useRedirect('study'); // 스터디/목표 기준 자동 리다이렉트
   useEffect(() => {
     if (url) {
       router.replace(url);
     }
+
+    setLoading(false);
   }, [url, router]);
 
   // 슬라이드 애니메이션 설정
@@ -110,6 +113,10 @@ export default function Guide() {
       paginate(-1);
     }
   };
+
+  if (loading) {
+    return <></>;
+  }
 
   return (
     <div


### PR DESCRIPTION
## 📄 변경 내용

- middleware: 로그인 확인만 담당하도록 수정, 스터디/목표 리다이렉트 로직은 useRedirect로 분리
- useRedirect: 스터디/목표 존재에 따라 적절한 경로 반환하는 훅 구현 및 적용
- deleteStudy: 삭제 성공 시 useRedirect로 리다이렉트
- deleteGoal: 삭제 성공 시 useRedirect로 리다이렉트 (목표 삭제 시 스터디는 유지, 목표만 변경)
- login: 로그인 성공 시 useRedirect로 리다이렉트
- guide: 가이드 페이지 진입 시 useRedirect로 자동 리다이렉트
- studyList mock 데이터: 실제 데이터 구조 및 totalCount 등 수정

---


## 📝 기타 참고 사항
- useRedirect 훅은 deleteType에 따라 스터디/목표 기준으로 동작
