### PR TITLE
chore:ui 수정 

### DIFF
--- a/src/features/get-goal-list/ui/StudyGoalList.tsx
+++ b/src/features/get-goal-list/ui/StudyGoalList.tsx
@@ -45,7 +45,7 @@ export default function StudyGoalList() {
         )}
       </div>
       {data.totalCount !== 0 ? (
-        <ul className="cursor-pointer py-4">
+        <ul className="flex cursor-pointer flex-col not-only:gap-4">
           {data.goals.map((goal) => {
             const goalItem: GoalListItem = {
               id: String(goal.id),
@@ -56,7 +56,7 @@ export default function StudyGoalList() {
                 onClick={() => handleClick(goalItem)}
                 key={goalItem.id}
                 className={clsx(
-                  'rounded-4 body-medium flex h-36 w-full items-center justify-between px-12 py-7',
+                  'rounded-4 body-medium hover:bg-surface-4 flex h-40 w-full items-center justify-between px-12 py-7',
                   goalItem.id === currentGoalId
                     ? 'bg-surface-4 text-text-secondary'
                     : 'bg-surface-2 text-text-tertiary',
@@ -64,7 +64,7 @@ export default function StudyGoalList() {
               >
                 <h3 className="flex items-center">{goalItem.title}</h3>
                 {role && goalItem.id === currentGoalId && (
-                  <div className="ml-auto">
+                  <div className="hover:rounded-3 hover:bg-border-emphasis ml-auto flex h-28 w-29 items-center justify-center">
                     <DeleteGoalButton
                       goalId={goalItem.id}
                       studyId={String(data.studyId)}

--- a/src/features/get-study-list/ui/StudyDropDown.tsx
+++ b/src/features/get-study-list/ui/StudyDropDown.tsx
@@ -52,14 +52,14 @@ export default function StudyDropDown({ onClick, data }: StudyDropDownProps) {
   };
 
   return (
-    <div className="bg-surface-4 rounded-b-6 scrollbar-hide xl:rounded-6 flex w-full flex-col items-center justify-start gap-24 p-16 xl:mt-12 xl:max-h-346 xl:overflow-y-scroll">
+    <div className="bg-surface-4 rounded-b-6 scrollbar-hide xl:rounded-6 xl:border-border-emphasis xl:-y-12 flex w-full flex-col items-center justify-start gap-24 p-16 xl:mt-12 xl:max-h-289 xl:gap-14 xl:overflow-y-scroll xl:border-1 xl:px-7">
       {data.studyList
         .filter((study: StudyItem) => study.id !== currentStudyId)
         .map((study: StudyItem) => (
           <div
             key={study.id}
             onClick={() => handleClick(study)}
-            className="flex h-76 min-h-76 w-full cursor-pointer flex-col"
+            className="xl:hover:bg-border-default rounded-6 flex h-76 min-h-76 w-full cursor-pointer flex-col xl:min-h-96 xl:gap-12 xl:px-8 xl:py-13"
           >
             <h3 className="text-text-secondary m-title-small xl:title-small">
               {study.title}

--- a/src/features/update-account/ui/UpdatePassword.tsx
+++ b/src/features/update-account/ui/UpdatePassword.tsx
@@ -75,6 +75,7 @@ export default function UpdatePassword() {
                 {...register('currentPassword')}
                 error={!!errors.currentPassword}
                 errorMessage={errors.currentPassword?.message}
+                type="password"
               />
             </div>
             <div className="flex flex-col gap-8">
@@ -86,12 +87,14 @@ export default function UpdatePassword() {
                 {...register('password')}
                 error={!!errors.password}
                 errorMessage={errors.password?.message}
+                type="password"
               />
               <TextField
                 placeholder="비밀번호를 다시 입력해주세요."
                 {...register('confirmPassword')}
                 error={!!errors.confirmPassword}
                 errorMessage={errors.confirmPassword?.message}
+                type="password"
               />
             </div>
           </form>

--- a/src/shared/ui/AppBar.tsx
+++ b/src/shared/ui/AppBar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useDrawerStore } from '@/shared/model';
 import BackIcon from '@/assets/icon-back2.svg';
 import CloseIcon from '@/assets/icon-close.svg';
@@ -11,11 +11,10 @@ interface AppBarProps {
 export default function AppBar({ pageName }: AppBarProps) {
   const { open } = useDrawerStore();
   const pathname = usePathname();
-  //const router = useRouter();
+  const router = useRouter();
 
   const handleBack = () => {
-    //router.back();
-    open();
+    router.back();
   };
 
   const isNote = pathname === '/note';

--- a/src/widgets/sidebar/ui/SideBarNav.tsx
+++ b/src/widgets/sidebar/ui/SideBarNav.tsx
@@ -4,11 +4,10 @@ import { useGoalStore } from '@/features/get-goal-list/model';
 import { StudyGoalList } from '@/features/get-goal-list/ui';
 import { useStudyStore } from '@/features/get-study-list/model';
 import { StudyDropDown, CurrentStudy } from '@/features/get-study-list/ui';
-import { useParams, usePathname, useRouter } from 'next/navigation';
+import { useParams, usePathname } from 'next/navigation';
 import { useState, useEffect } from 'react';
 
 export default function SideBarNav() {
-  const router = useRouter();
   const { setStudyId, currentStudyId } = useStudyStore();
   const { setGoalId, resetGoalId } = useGoalStore();
   const pathname = usePathname();

--- a/src/widgets/sidebar/ui/SideBarNav.tsx
+++ b/src/widgets/sidebar/ui/SideBarNav.tsx
@@ -40,15 +40,6 @@ export default function SideBarNav() {
 
   // 드랍다운 오픈 여부
   const handleClick = () => {
-    // 스터디가 하나일 경우, 현재 스터디 누르면 해당 페이지로 이동
-    if (
-      (studyData.totalCount === 1 && pathname?.startsWith('/account')) ||
-      pathname?.startsWith('/note') ||
-      pathname?.startsWith('/todolist-detail')
-    ) {
-      setIsOpen(false);
-      router.push('/');
-    }
     setIsOpen(!isOpen);
   };
 


### PR DESCRIPTION
## 📌 PR 제목

> chore:ui 수정

## 📄 변경 내용

- 스터디 목록 및 목표 hover 적용
- 비밀번호 필드 type="password"로 수정
- Appbar 뒤로가기 클릭시 이전 페이지로 이동하도록 수정

## 📸 UI 스크린샷

### 스터디 목록 hover시 UI
<img width="347" height="912" alt="image" src="https://github.com/user-attachments/assets/ca8042c7-649e-4665-ba1c-280fc103ec44" />

### 스터디 목표 hover시 UI
<img width="331" height="196" alt="image" src="https://github.com/user-attachments/assets/567a3e71-fc3e-4662-9bc1-34d047a39d5e" />

### 목표 삭제 hover시 UI
<img width="339" height="186" alt="image" src="https://github.com/user-attachments/assets/88a9205c-2496-4664-a5a9-23328b91678a" />